### PR TITLE
Fix issue where + New Note button is offscreen

### DIFF
--- a/Customizable-toolbar-on-iPad/Customizable-toolbar-on-iPad.swift
+++ b/Customizable-toolbar-on-iPad/Customizable-toolbar-on-iPad.swift
@@ -53,7 +53,6 @@ struct NoteList: View {
         .toolbar {
             ToolbarItem(placement: .bottomBar) {
                 HStack {
-                    Spacer()
                     Button {
                         let newNote = Note(text: "", id: appState.notes.count)
                         appState.notes.append(newNote)


### PR DESCRIPTION
My son was trying to get your example code to work on the latest XCode / iOS SDK, and we were puzzled by the empty screen that appears by using the code presented here.

It looks like the `Spacer()` is pushing the button offscreen, so it doesn't appear at all. Removing the line fixes the issue.